### PR TITLE
BUG FIX: double dots eliminated in VDB sequence saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ After installing Zig, Blender, and Python, run `zig build` from the project repo
 
 ## 🗃️ Test Files
 If you wish to run tests, download the [T1](https://s3.amazonaws.com/openneuro.org/ds003548/sub-01/anat/sub-01_T1w.nii.gz?versionId=5ZTXVLawdWoVNWe5XVuV6DfF2BnmxzQz) and [BOLD](https://s3.amazonaws.com/openneuro.org/ds003548/sub-01/func/sub-01_task-emotionalfaces_run-1_bold.nii.gz?versionId=tq8Y3ktm31Aa8JB0991n9K0XNmHyRS1Q) images to `./media`
+Unzip both of these `.gz` files before running the tests.
 
 ## 🛤️ Change Hard-Coded paths
 `./src/config.zig.zon` includes full, hard-coded paths to these files as well as your VDB output directory. Set these to the corresponding paths on your machine (they will be `./output` and the filepaths in `./media` respectively).

--- a/blender_plugin/__init__.py
+++ b/blender_plugin/__init__.py
@@ -131,7 +131,7 @@ class LoadVolume(bpy.types.Operator):  # LLM: drop-in rewrite for reactive loadi
             if self._step == 0:
                 context.scene.volume_info_text = "⏳ Parsing header..."
             elif self._step == 1:
-                report = load_nifti1(self._path)
+                load_nifti1(self._path)
                 context.scene.volume_info_text = "📊 Building VDB data..."
             elif self._step == 2:
                 data = build_volume_data(self._path)

--- a/blender_plugin/neurovolume_lib.py
+++ b/blender_plugin/neurovolume_lib.py
@@ -21,11 +21,11 @@ def get_basename(path):
     hierarchy = path.split("/")
     return hierarchy[-1].split(".")[0]
 
+
 def get_folder(path):
     """Returns the folder in which the path points to"""
     hiearchy = path.split("/")
     return "/".join(hiearchy[:-1])
-
 
 
 def nifti1_to_VDB(filepath: str, normalize: bool) -> str:
@@ -74,7 +74,7 @@ def pixdim(filepath: str, filetype: str, dim: int) -> float:
             raise ValueError(err_msg)
 
 
-# Not really used, tbh! #WARN: never tested and test file just puts this as 0 for some reason
+# WARN: never tested or used and test file just puts this as 0 for some reason
 def slice_duration(filepath: str, filetype: str) -> int:
     match filetype:
         case "NIfTI1":
@@ -101,7 +101,7 @@ def source_fps(filepath: str, filetype: str) -> int:
     match filetype:
         case "NIfTI1":
             if num_frames(filepath, filetype) == 1:
-                #staic file, frames per second is zero
+                # staic file, frames per second is zero
                 return 0
 
             time_unit = unit(filepath, filetype, "time")

--- a/src/root.zig
+++ b/src/root.zig
@@ -60,7 +60,7 @@ pub fn nifti1ToVDB(
             const frame_path = try zools.sequence.elementName(
                 vdb_seq_folder_slice,
                 basename,
-                ".vdb",
+                "vdb",
                 frame,
                 leading_zeros,
                 arena_alloc,

--- a/src/vdb543.zig
+++ b/src/vdb543.zig
@@ -435,6 +435,7 @@ pub fn writeFrame(
         buffer.*, //EXORCISE: This pointer pattern seems cursed
         arena_alloc,
     );
+
     return vdb_filepath;
 }
 


### PR DESCRIPTION
Previously BOLD sequences were saved as `filename..vdb`. This is an issue on its own but it also broke the importing of VDB sequences into blender. This PR fixes it.