### PR TITLE
Nested Loops Flatten and Minmax improved

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .zools = .{
-            .url = "git+https://github.com/joachimbbp/zools#e6684fea057642e8ac32a397652953fceb95aaa8",
-            .hash = "zools-0.0.0-VPOS2i5kAACRVxWL801rXofHbRhjvTUOVN7-6SAt2Zrg",
+            .url = "git+https://github.com/joachimbbp/zools#81e7cf65d34b6a58c48aa6ce14a6698c1c18d601",
+            .hash = "zools-0.0.0-VPOS2hZsAADTJdiA2nI6fLIlpycvhOV3csIyqOu6bjZ9",
         },
     },
 

--- a/src/nifti1.zig
+++ b/src/nifti1.zig
@@ -91,7 +91,15 @@ pub const Image = struct {
     data_type: DataType,
     bytes_per_voxel: u16,
 
-    pub fn getAt4D(self: *const Image, xpos: usize, ypos: usize, zpos: usize, tpos: usize, normalize: bool, minmax: [2]f32) !f32 {
+    pub fn getAt4D(
+        self: *const Image,
+        xpos: usize,
+        ypos: usize,
+        zpos: usize,
+        tpos: usize,
+        normalize: bool,
+        minmax: [2]f32,
+    ) !f32 {
         const nx: usize = @intCast(self.header.dim[1]);
         const ny: usize = @intCast(self.header.dim[2]);
         const nz: usize = @intCast(self.header.dim[3]);

--- a/src/nifti1.zig
+++ b/src/nifti1.zig
@@ -218,6 +218,7 @@ pub fn getTransform(h: Header) ![4][4]f64 {
     };
 }
 
+//DEPRECATED: in favor of root.MinMax
 pub fn MinMax3D(img: Image) ![2]f32 {
     var minmax: [2]f32 = .{ std.math.floatMax(f32), -std.math.floatMax(f32) };
     //dim is [num dimensions, x, y, z, time ...]

--- a/src/root.zig
+++ b/src/root.zig
@@ -216,8 +216,11 @@ pub fn nifti1ToVDB(
 
             const num_voxels = img.data.len / @as(usize, @intCast(img.bytes_per_voxel)); //LLM:
             const num_frames: usize = @intCast(img.header.dim[4]);
-            //            const vpf = num_voxels / num_frames;
-            const vpf: usize = @intCast(@as(u16, @intCast(hdr.dim[1] * hdr.dim[2] * hdr.dim[3])) * img.bytes_per_voxel); //LLM: fix
+            const vpf = @as(usize, @intCast(hdr.dim[1])) *
+                @as(usize, @intCast(hdr.dim[2])) *
+                @as(usize, @intCast(hdr.dim[3])) *
+                @as(usize, @intCast(img.bytes_per_voxel));
+
             print("🔎 INSPECT: Voxels Per Frame: {d}/{d}={d}\n", .{ num_voxels, num_frames, vpf });
             //this should always be an int!
             const leading_zeros = zools.math.numDigitsShort(@bitCast(img.header.dim[4]));

--- a/src/root.zig
+++ b/src/root.zig
@@ -220,8 +220,8 @@ pub fn nifti1ToVDB(
             );
             filepath = versioned_vdb_filepath.items;
         },
-        //_: Time sequence
 
+        //_: Time Series
         4 => {
             const transform = zools.matrix.IdentityMatrix4x4;
             //FIX: native transform doesn't work with bold as of right now!
@@ -258,17 +258,16 @@ pub fn nifti1ToVDB(
                 //I guess I could clean up this code with splatting or something...
                 //It would be nice to capture the case (3 and 4) and then use that to build the num_dims,
                 //splat from there, etc!
-                var cart = [_]usize{ 0, 0, 0, 0 };
+                var cart = [_]usize{ 0, 0, 0 };
                 var idx: usize = 0;
-                const dim_list: [4]usize = .{
+                const dim_list: [3]usize = .{
                     @intCast(hdr.dim[1]),
                     @intCast(hdr.dim[2]),
                     @intCast(hdr.dim[3]),
-                    @intCast(hdr.dim[4]),
-                }; //is this the most performant type?
+                };
 
                 while (true) {
-                    if (increment_cartesian(4, &cart, dim_list) == false) {
+                    if (increment_cartesian(3, &cart, dim_list) == false) {
                         break;
                     }
                     idx += 1;

--- a/src/root.zig
+++ b/src/root.zig
@@ -19,7 +19,7 @@ const SupportError = error{
 
 fn linear_to_cartesian(
     linear_index: usize,
-    comptime num_dims: comptime_int, //number of dimensions
+    comptime num_dims: comptime_int, //number of dimensions //HACK: feels redundant?
     comptime DimensionType: type,
     dims: *const [num_dims]DimensionType,
 ) [num_dims]usize {
@@ -216,7 +216,8 @@ pub fn nifti1ToVDB(
 
             const num_voxels = img.data.len / @as(usize, @intCast(img.bytes_per_voxel)); //LLM:
             const num_frames: usize = @intCast(img.header.dim[4]);
-            const vpf = num_voxels / num_frames;
+            //            const vpf = num_voxels / num_frames;
+            const vpf: usize = @intCast(@as(u16, @intCast(hdr.dim[1] * hdr.dim[2] * hdr.dim[3])) * img.bytes_per_voxel); //LLM: fix
             print("🔎 INSPECT: Voxels Per Frame: {d}/{d}={d}\n", .{ num_voxels, num_frames, vpf });
             //this should always be an int!
             const leading_zeros = zools.math.numDigitsShort(@bitCast(img.header.dim[4]));
@@ -236,7 +237,7 @@ pub fn nifti1ToVDB(
                         hdr.dim[1..4],
                     );
                     const res_value = getValue(
-                        &img.data,
+                        &frame_data, //LLM: caught this eroneously left as `img.data`
                         idx,
                         img.bytes_per_voxel,
                         i16,

--- a/src/root.zig
+++ b/src/root.zig
@@ -49,11 +49,15 @@ pub fn nifti1ToVDB(
 
             //Jan's linear_to_cartesian
             const num_voxels = img.data.len / @as(usize, @intCast(img.bytes_per_voxel)); //LLM:
+            const nx: usize = @intCast(hdr.dim[1]);
+            const ny: usize = @intCast(hdr.dim[2]);
+            //  const nz: usize = @intCast(hdr.dim[3]);
+
             for (0..num_voxels) |voxel_idx| {
-                var cart: [3]usize = @splat(0);
-                for (0.., img.header.dim[1..4]) |i, di| {
-                    cart[i] = @rem(voxel_idx, @as(usize, @intCast(di)));
-                }
+                //LLM:
+                const x = voxel_idx % nx;
+                const y = (voxel_idx / nx) % ny;
+                const z = voxel_idx / (nx * ny);
 
                 const bit_start: usize = voxel_idx * @as(usize, @intCast(img.bytes_per_voxel));
                 const bit_end: usize = (voxel_idx + 1) * @as(usize, @intCast(img.bytes_per_voxel));
@@ -74,7 +78,7 @@ pub fn nifti1ToVDB(
                 }
                 try vdb543.setVoxel(
                     &vdb,
-                    .{ @intCast(cart[0]), @intCast(cart[1]), @intCast(cart[2]) },
+                    .{ @intCast(x), @intCast(y), @intCast(z) },
                     @floatCast(res_value),
                     arena_alloc,
                 );

--- a/src/vdb543.zig
+++ b/src/vdb543.zig
@@ -394,7 +394,7 @@ const Img = nifti1.Image;
 pub fn buildFrame(
     arena_alloc: std.mem.Allocator,
     img_deprecated: Img,
-    minmax_deprecated: [2]f32, //DEPRECATED: will eventually live in img
+    minmax_deprecated: [2]f32, //DEPRECATED:
     normalize: bool,
     frame: usize,
 ) !VDB {


### PR DESCRIPTION
Previously, data was iterated over Cartesian coordinates in nested loops. This branch iterates over the data directly, improving performance, readability, and makes the functions more universal (which will be useful for adding different file types). This change shaves off about 6 seconds from VDB creation for the static `NIfTI1` test file and about 0.5 seconds for the BOLD when running `zig build test`.

Big thank you to [Jan Burgy](https://bur.gy/) for knowing about and showing me these techniques.

Min-Max improvements:
- Now iterates over the all data without regard to Cartesian coordinates. Is not limited to a single 3D slice of 4D (or n-dimensional) data.
- Includes a third field for the difference between min and max values